### PR TITLE
Add support for D2-14-41

### DIFF
--- a/enoceanmqtt/overlays/homeassistant/mapping.yaml
+++ b/enoceanmqtt/overlays/homeassistant/mapping.yaml
@@ -1329,6 +1329,97 @@
                    {% else %}Error
                    {% endif %}
                  icon: "mdi:weather-windy"
+      0x41:
+         device_config:
+            command: ""
+            channel: ""
+            log_learn: ""
+            direction: ""
+            answer: ""
+         entities:
+            - component: "sensor"
+              name: "t_raw"
+              config:
+                 state_topic: ""
+                 value_template: "{{ value_json.TMP }}"
+                 device_class: "temperature"
+                 state_class: "measurement"
+                 unit_of_measurement: "°C"
+                 enabled_by_default: "false"
+            - component: "sensor"
+              name: "tempC"
+              config:
+                 state_topic: ""
+                 value_template: "{{ value_json.TMP | round(1) }}"
+                 device_class: "temperature"
+                 state_class: "measurement"
+                 unit_of_measurement: "°C"
+            - component: "sensor"
+              name: "h_raw"
+              config:
+                 state_topic: ""
+                 value_template: "{{ value_json.HUM }}"
+                 device_class: "humidity"
+                 state_class: "measurement"
+                 unit_of_measurement: "%"
+                 enabled_by_default: "false"
+            - component: "sensor"
+              name: "hum"
+              config:
+                 state_topic: ""
+                 value_template: "{{ value_json.HUM | round(1) }}"
+                 device_class: "humidity"
+                 state_class: "measurement"
+                 unit_of_measurement: "%"
+            - component: "sensor"
+              name: "lux"
+              config:
+                 state_topic: ""
+                 value_template: "{{ value_json.ILL }}"
+                 device_class: "illuminance"
+                 state_class: "measurement"
+                 unit_of_measurement: "lx"
+            - component: "sensor"
+              name: "acceleration"
+              config:
+                 state_topic: ""
+                 value_template: >-
+                   {% if value_json.ACC == 0 %}Periodic Update
+                   {% elif value_json.ACC == 1 %}Threshold 1 exceeded
+                   {% elif value_json.ACC == 2 %}Threshold 2 exceeded
+                   {% else %}Error
+                   {% endif %}
+            - component: "sensor"
+              name: "ACX"
+              config:
+                 state_topic: ""
+                 value_template: "{{ value_json.ACX }}"
+                 device_class: "weight"
+                 state_class: "measurement"
+                 unit_of_measurement: "g"
+            - component: "sensor"
+              name: "ACY"
+              config:
+                 state_topic: ""
+                 value_template: "{{ value_json.ACY }}"
+                 device_class: "weight"
+                 state_class: "measurement"
+                 unit_of_measurement: "g"
+            - component: "sensor"
+              name: "ACZ"
+              config:
+                 state_topic: ""
+                 value_template: "{{ value_json.ACZ }}"
+                 device_class: "weight"
+                 state_class: "measurement"
+                 unit_of_measurement: "g"
+            - component: binary_sensor
+              name: "contact"
+              config:
+                 state_topic: ""
+                 value_template: "{{ value_json.CO }}"
+                 payload_on: "0"
+                 payload_off: "1"
    0x50:
       0x00:
          device_config:


### PR DESCRIPTION
Hi, looks like I was able to successfully add support for D2-14-41 Multisensor (Indoor -Temperature, Humidity XYZ Acceleration, Illumination, Contact Sensor).
Here the debug output:

2025-01-21 22:09:39,981 DEBUG: 04:13:8D:85->FF:FF:FF:FF (-82 dBm): 0x01 ['0xd2', '0x9e', '0x1f', '0x80', '0xd', '0xe3', '0xe2', '0xfb', '0xd7', '0xc0', '0x4', '0x13', '0x8d', '0x85', '0x80'] ['0x0', '0xff', '0xff', '0xff', '0xff', '0x52', '0x0'] OrderedDict()
2025-01-21 22:09:39,982 DEBUG: enoceanmqtt/Multisensor_D2-14-41: TMP (Temperature 10)=23.200000000000003 °C
2025-01-21 22:09:39,982 DEBUG: enoceanmqtt/Multisensor_D2-14-41: HUM (Rel. Humidity (linear))=63.0 %
2025-01-21 22:09:39,983 DEBUG: enoceanmqtt/Multisensor_D2-14-41: ILL (Illumination (linear))=111.0 lx
2025-01-21 22:09:39,983 DEBUG: enoceanmqtt/Multisensor_D2-14-41: ACC (Acceleration Status)=Periodic Update 
2025-01-21 22:09:39,983 DEBUG: enoceanmqtt/Multisensor_D2-14-41: ACX (Absolute Acceleration on X axis)=-0.015000000000000124 g
2025-01-21 22:09:39,983 DEBUG: enoceanmqtt/Multisensor_D2-14-41: ACY (Absolute Acceleration on Y axis)=0.015000000000000124 g
2025-01-21 22:09:39,983 DEBUG: enoceanmqtt/Multisensor_D2-14-41: ACZ (Absolute Acceleration on Z axis)=1.0100000000000002 g
2025-01-21 22:09:39,983 DEBUG: enoceanmqtt/Multisensor_D2-14-41: CO (Contact)=Open 
2025-01-21 22:09:39,983 DEBUG: enoceanmqtt/Multisensor_D2-14-41: Sent MQTT: {"_RSSI_": -82, "_DATE_": "2025-01-21T22:09:39.981177", "TMP": 23.200000000000003, "HUM": 63.0, "ILL": 111.0, "ACC": 0, "ACX": -0.015000000000000124, "ACY": 0.015000000000000124, "ACZ": 1.0100000000000002, "CO": 0}
2025-01-21 22:09:39,983 DEBUG: Sending PUBLISH (d0, q0, r1, m49), 'b'enoceanmqtt/Multisensor_D2-14-41'', ... (214 bytes)

Many thanks and take care